### PR TITLE
Refresh displayed keys on import

### DIFF
--- a/Source/ActionController.m
+++ b/Source/ActionController.m
@@ -868,8 +868,9 @@
 			
 			NSDictionary *statusDict = gc.statusDict;
 			if (statusDict) {
-				sheetController.msgText = [self importResultWithStatusDict:statusDict];
-				
+				[self refreshDisplayedKeys:self];
+
+				sheetController.msgText = [self importResultWithStatusDict:statusDict];				
 				sheetController.sheetType = SheetTypeShowResult;
 				[sheetController runModalForWindow:mainWindow];
 			}


### PR DESCRIPTION
Hello.

This change adds a call to refreshDisplayedKeys: on successful import.

I had imported a file of public keys but only one key from the bunch was displayed.
