### PR TITLE
Xcode is required to make this project

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -42,3 +42,4 @@ System Requirements
 * Mac OS X >= 10.6
 * Libmacgpg
 * GnuPG
+* Xcode


### PR DESCRIPTION
```
$ make
xcodebuild -project GPGKeychain.xcodeproj -target "GPG Keychain" build 
xcode-select: error: tool 'xcodebuild' requires Xcode, but active developer directory '/Library/Developer/CommandLineTools' is a command line tools instance
make: *** [GPG Keychain] Error 1
```